### PR TITLE
Remove dependency pathlib2 from tox.ini

### DIFF
--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -21,7 +21,6 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     poetry
-    {py27}: pathlib2
 ; If you want to make tox run the tests with the same versions, commit
 ; the poetry.lock to source control
 commands_pre = poetry install


### PR DESCRIPTION
Remove dependency pathlib2 from tox.ini since Python 2 is no longer
supported in this project.

@see https://tox.readthedocs.io/en/latest/config.html#generating-environments-conditional-settings
@see https://tox.readthedocs.io/en/latest/config.html#complex-factor-conditions

Hi, I found one more backward compatibility definition for Python 2.