### PR TITLE
Fix tox for generated packages

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -57,3 +57,7 @@ yapf = "*"
 [tool.poetry.scripts]
 {{ cookiecutter.project_slug }} = '{{ cookiecutter.project_slug }}.cli:main'
 {%- endif %}
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -11,16 +11,16 @@ python =
 
 [testenv:lint]
 basepython = python
-commands = invoke lint
+commands = poetry run invoke lint
 
 [testenv:format]
 basepython = python
-commands = invoke format --check
+commands = poetry run invoke format --check
 
 [testenv]
 ; If you want to make tox run the tests with the same versions, commit
 ; the poetry.lock to source control
 commands_pre = poetry install
-commands = invoke test
+commands = poetry run invoke test
 
 

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+isolated_build = true
 envlist = py35, py36, py37, py38, lint, format
 
 [travis]
@@ -17,10 +18,6 @@ basepython = python
 commands = invoke format --check
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}
-deps =
-    poetry
 ; If you want to make tox run the tests with the same versions, commit
 ; the poetry.lock to source control
 commands_pre = poetry install


### PR DESCRIPTION
The conversion to `poetry` was incomplete. When running `tox` on a freshly-created package it would fail (#21).

Following the FAQ at https://python-poetry.org/docs/faq/#is-tox-supported seems to be the right way to integrate `poetry` and `tox`

Fixes #21 and fixes #18 